### PR TITLE
add multiline error message support

### DIFF
--- a/src/AlbumApp/album_page.py
+++ b/src/AlbumApp/album_page.py
@@ -40,7 +40,7 @@ class Album(Page):
             photo = photo_list[index]
             self.draw_photo(photo)
         else:
-            self.print_error("Album is empty")
+            self.print_error("Album is empty. If download is enabled, check that scheduled download is off or the same day as today. Turn glance off and on to retry.")
 
     def download_photos(self):
         if self.should_download:

--- a/src/page.py
+++ b/src/page.py
@@ -24,11 +24,34 @@ class Page:
         else:
             return None
     
+    def split_message(self, message):
+        NEW_LINE_BREAK = 180
+
+        words = message.split(" ")
+        formatted_message = ""
+        line = ""
+        for word in words:
+            if self.draw.textlength(line + ' ' + word) > NEW_LINE_BREAK:
+                formatted_message = formatted_message + line + '\n'
+                line = ""
+            line = line + ' ' + word
+
+        formatted_message = formatted_message + line
+        return formatted_message
+
     def print_error(self, err_msg="something went wrong on the page."):
         font = os.path.join(self.font_dir, "Font.ttc")
         font_error = ImageFont.truetype(font, 24)
-        error_message = err_msg
-        self.draw.rectangle([20, 374, 460, 450], fill=255, outline="black", width=4)
+        error_message = self.split_message(err_msg)
+        
+        BOX_PADDING = 10
+        box = self.draw.textbbox((50, 400), error_message, font=font_error)
+        box = (box[0] - BOX_PADDING,
+               box[1] - BOX_PADDING,
+               box[2] + BOX_PADDING,
+               box[3] + BOX_PADDING)
+        
+        self.draw.rectangle(box, fill=255, outline="black", width=4)
         self.draw.text((50, 400), error_message, font=font_error, fill=0)
 
     def run(self):


### PR DESCRIPTION
Fixes #56 

Add support for long error messages. Text wraps around to a new line and creates a bounding box based on the size of the message with padding

<img width="488" height="815" alt="image" src="https://github.com/user-attachments/assets/f5172bca-b0d1-442d-af6f-e33b5a44ab6e" />
