### PR TITLE
resize image before displaying

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ Glance is a picture frame-like e-ink tablet that is designed to display glance-a
 It is made using a 7.5 inch e-ink display, rasberry pi 3b, pi sugar battery hat and a 3D printed casing.
 
 It currently has 2 apps:
-- Current Contests - Displays the current open contests on [instructables.com](https://instructables.com)
-- Photo Album - Displays a random image from shared google photos album 
+- InstructablesApp - Displays the current open contests on [instructables.com](https://instructables.com)
+- AlbumApp - Displays a random image from a shared google photos album. Pictures can also be manually added 
 
 ## Getting Started
 ### Hardware

--- a/src/AlbumApp/album_page.py
+++ b/src/AlbumApp/album_page.py
@@ -30,7 +30,7 @@ class Album(Page):
                         self.should_download = False if value.lower() == 'false' else True
 
     def draw_photo(self, photo_name):
-        bmp = Image.open(os.path.join(self.pic_dir, photo_name))
+        bmp = album_pictures.resize_image(os.path.join(self.pic_dir, photo_name))
         self.Limage.paste(bmp, (0, 0))
     
     def get_random_photo(self):


### PR DESCRIPTION
Closes #62 

Updated album_page.py to call album_pictures.resize_image() before pasting the image on glance's display. This makes it so that manually added photos which do not get automatically resized will be displayed properly. Already formatted images are not affected.

This bring to question whether pre-formatting the images is the right approach (definitely better for storage) but as google photos download feature will be re-worked, no need to make those changes here.